### PR TITLE
spotify

### DIFF
--- a/src/auth/services/crypto.service.ts
+++ b/src/auth/services/crypto.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from "@nestjs/common"
+import type { ConfigService } from "@nestjs/config"
+import * as crypto from "crypto"
+
+@Injectable()
+export class CryptoService {
+  private readonly algorithm = "aes-256-gcm"
+  private readonly secretKey: Buffer
+
+  constructor(private configService: ConfigService) {
+    const key = this.configService.get<string>("ENCRYPTION_KEY")
+    if (!key || key.length !== 32) {
+      throw new Error("ENCRYPTION_KEY must be exactly 32 characters long")
+    }
+    this.secretKey = Buffer.from(key, "utf8")
+  }
+
+  /**
+   * Encrypt a string value
+   */
+  encrypt(text: string): string {
+    const iv = crypto.randomBytes(16)
+    const cipher = crypto.createCipher(this.algorithm, this.secretKey)
+    cipher.setAAD(Buffer.from("mixmatch-auth", "utf8"))
+
+    let encrypted = cipher.update(text, "utf8", "hex")
+    encrypted += cipher.final("hex")
+
+    const authTag = cipher.getAuthTag()
+
+    // Combine iv, authTag, and encrypted data
+    return `${iv.toString("hex")}:${authTag.toString("hex")}:${encrypted}`
+  }
+
+  /**
+   * Decrypt a string value
+   */
+  decrypt(encryptedData: string): string {
+    const [ivHex, authTagHex, encrypted] = encryptedData.split(":")
+
+    const iv = Buffer.from(ivHex, "hex")
+    const authTag = Buffer.from(authTagHex, "hex")
+
+    const decipher = crypto.createDecipher(this.algorithm, this.secretKey)
+    decipher.setAAD(Buffer.from("mixmatch-auth", "utf8"))
+    decipher.setAuthTag(authTag)
+
+    let decrypted = decipher.update(encrypted, "hex", "utf8")
+    decrypted += decipher.final("utf8")
+
+    return decrypted
+  }
+
+  /**
+   * Generate a secure random state for OAuth
+   */
+  generateState(): string {
+    return crypto.randomBytes(32).toString("hex")
+  }
+}

--- a/src/auth/spotify/dto/spotify-callback.dto.ts
+++ b/src/auth/spotify/dto/spotify-callback.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsOptional, IsString } from "class-validator"
+
+export class SpotifyCallbackDto {
+  @IsNotEmpty()
+  @IsString()
+  code: string
+
+  @IsOptional()
+  @IsString()
+  state?: string
+
+  @IsOptional()
+  @IsString()
+  error?: string
+}

--- a/src/auth/spotify/interfaces/spotify-user.interface.ts
+++ b/src/auth/spotify/interfaces/spotify-user.interface.ts
@@ -1,0 +1,23 @@
+export interface SpotifyUser {
+  id: string
+  display_name: string
+  email?: string
+  images?: Array<{
+    url: string
+    height: number
+    width: number
+  }>
+  followers?: {
+    total: number
+  }
+  country?: string
+  product?: string
+}
+
+export interface SpotifyTokenResponse {
+  access_token: string
+  token_type: string
+  scope: string
+  expires_in: number
+  refresh_token: string
+}

--- a/src/auth/spotify/spotify-oauth.controller.ts
+++ b/src/auth/spotify/spotify-oauth.controller.ts
@@ -1,0 +1,98 @@
+import { Controller, Get, Query, HttpStatus } from "@nestjs/common"
+import type { Response } from "express"
+import type { SpotifyOAuthService } from "./spotify-oauth.service"
+import type { SpotifyCallbackDto } from "./dto/spotify-callback.dto"
+
+@Controller("auth/spotify")
+export class SpotifyOAuthController {
+  constructor(private readonly spotifyOAuthService: SpotifyOAuthService) {}
+
+  /**
+   * Initiate Spotify OAuth flow
+   * GET /auth/spotify
+   */
+  @Get()
+  async initiateAuth(res: Response) {
+    const { url, state } = this.spotifyOAuthService.getAuthorizationUrl()
+
+    // Store state in session/cookie for validation (optional but recommended)
+    res.cookie("spotify_oauth_state", state, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      maxAge: 10 * 60 * 1000, // 10 minutes
+    })
+
+    return res.redirect(url)
+  }
+
+  /**
+   * Handle Spotify OAuth callback
+   * GET /auth/spotify/callback
+   */
+  @Get("callback")
+  async handleCallback(query: SpotifyCallbackDto, res: Response) {
+    try {
+      const result = await this.spotifyOAuthService.handleCallback(query)
+
+      // Set JWT tokens as HTTP-only cookies
+      res.cookie("access_token", result.tokens.accessToken, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        maxAge: 60 * 60 * 1000, // 1 hour
+      })
+
+      res.cookie("refresh_token", result.tokens.refreshToken, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+      })
+
+      // Redirect to frontend success page
+      const frontendUrl = process.env.FRONTEND_URL || "http://localhost:3000"
+      return res.redirect(`${frontendUrl}/auth/success`)
+    } catch (error) {
+      // Redirect to frontend error page
+      const frontendUrl = process.env.FRONTEND_URL || "http://localhost:3000"
+      return res.redirect(`${frontendUrl}/auth/error?message=${encodeURIComponent(error.message)}`)
+    }
+  }
+
+  /**
+   * Get current user's Spotify profile (protected route example)
+   */
+  @Get("profile")
+  async getProfile(@Query("userId") userId: string) {
+    try {
+      const accessToken = await this.spotifyOAuthService.getDecryptedAccessToken(userId)
+
+      const response = await fetch("https://api.spotify.com/v1/me", {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+
+      if (!response.ok) {
+        // Try to refresh token if expired
+        const newAccessToken = await this.spotifyOAuthService.refreshSpotifyToken(userId)
+        const retryResponse = await fetch("https://api.spotify.com/v1/me", {
+          headers: {
+            Authorization: `Bearer ${newAccessToken}`,
+          },
+        })
+
+        if (!retryResponse.ok) {
+          throw new Error("Failed to fetch Spotify profile")
+        }
+
+        return await retryResponse.json()
+      }
+
+      return await response.json()
+    } catch (error) {
+      return {
+        error: error.message,
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
+      }
+    }
+  }
+}

--- a/src/auth/spotify/spotify-oauth.module.ts
+++ b/src/auth/spotify/spotify-oauth.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common"
+import { ConfigModule } from "@nestjs/config"
+import { SpotifyOAuthService } from "./spotify-oauth.service"
+import { SpotifyOAuthController } from "./spotify-oauth.controller"
+import { UsersModule } from "../../users/users.module"
+import { AuthModule } from "../auth.module"
+import { CryptoService } from "../services/crypto.service"
+
+@Module({
+  imports: [ConfigModule, UsersModule, AuthModule],
+  providers: [SpotifyOAuthService, CryptoService],
+  controllers: [SpotifyOAuthController],
+  exports: [SpotifyOAuthService],
+})
+export class SpotifyOAuthModule {}

--- a/src/auth/spotify/spotify-oauth.service.ts
+++ b/src/auth/spotify/spotify-oauth.service.ts
@@ -1,0 +1,228 @@
+import { Injectable, BadRequestException, InternalServerErrorException } from "@nestjs/common"
+import type { ConfigService } from "@nestjs/config"
+import type { UsersService } from "../../users/users.service"
+import type { AuthService } from "../auth.service"
+import type { CryptoService } from "../services/crypto.service"
+import type { SpotifyUser, SpotifyTokenResponse } from "./interfaces/spotify-user.interface"
+import type { SpotifyCallbackDto } from "./dto/spotify-callback.dto"
+import { MusicProvider } from "@prisma/client"
+
+@Injectable()
+export class SpotifyOAuthService {
+  private readonly spotifyClientId: string
+  private readonly spotifyClientSecret: string
+  private readonly spotifyRedirectUri: string
+  private readonly spotifyAuthUrl = "https://accounts.spotify.com/authorize"
+  private readonly spotifyTokenUrl = "https://accounts.spotify.com/api/token"
+  private readonly spotifyApiUrl = "https://api.spotify.com/v1"
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly usersService: UsersService,
+    private readonly authService: AuthService,
+    private readonly cryptoService: CryptoService,
+  ) {
+    this.spotifyClientId = this.configService.get<string>("SPOTIFY_CLIENT_ID")!
+    this.spotifyClientSecret = this.configService.get<string>("SPOTIFY_CLIENT_SECRET")!
+    this.spotifyRedirectUri = this.configService.get<string>("SPOTIFY_REDIRECT_URI")!
+
+    if (!this.spotifyClientId || !this.spotifyClientSecret || !this.spotifyRedirectUri) {
+      throw new Error("Missing required Spotify OAuth configuration")
+    }
+  }
+
+  /**
+   * Generate Spotify OAuth authorization URL
+   */
+  getAuthorizationUrl(): { url: string; state: string } {
+    const state = this.cryptoService.generateState()
+    const scopes = [
+      "user-read-private",
+      "user-read-email",
+      "user-library-read",
+      "user-top-read",
+      "playlist-read-private",
+      "playlist-read-collaborative",
+    ].join(" ")
+
+    const params = new URLSearchParams({
+      response_type: "code",
+      client_id: this.spotifyClientId,
+      scope: scopes,
+      redirect_uri: this.spotifyRedirectUri,
+      state,
+      show_dialog: "true", // Force user to approve app each time
+    })
+
+    const url = `${this.spotifyAuthUrl}?${params.toString()}`
+
+    return { url, state }
+  }
+
+  /**
+   * Exchange authorization code for access and refresh tokens
+   */
+  private async exchangeCodeForTokens(code: string): Promise<SpotifyTokenResponse> {
+    const params = new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: this.spotifyRedirectUri,
+    })
+
+    const authHeader = Buffer.from(`${this.spotifyClientId}:${this.spotifyClientSecret}`).toString("base64")
+
+    try {
+      const response = await fetch(this.spotifyTokenUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Authorization: `Basic ${authHeader}`,
+        },
+        body: params.toString(),
+      })
+
+      if (!response.ok) {
+        const error = await response.text()
+        throw new Error(`Spotify token exchange failed: ${error}`)
+      }
+
+      return await response.json()
+    } catch (error) {
+      throw new InternalServerErrorException(`Failed to exchange code for tokens: ${error.message}`)
+    }
+  }
+
+  /**
+   * Fetch user profile from Spotify API
+   */
+  private async fetchSpotifyUserProfile(accessToken: string): Promise<SpotifyUser> {
+    try {
+      const response = await fetch(`${this.spotifyApiUrl}/me`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+
+      if (!response.ok) {
+        const error = await response.text()
+        throw new Error(`Spotify API request failed: ${error}`)
+      }
+
+      return await response.json()
+    } catch (error) {
+      throw new InternalServerErrorException(`Failed to fetch user profile: ${error.message}`)
+    }
+  }
+
+  /**
+   * Handle Spotify OAuth callback
+   */
+  async handleCallback(callbackDto: SpotifyCallbackDto): Promise<{
+    user: any
+    tokens: { accessToken: string; refreshToken: string }
+  }> {
+    if (callbackDto.error) {
+      throw new BadRequestException(`Spotify OAuth error: ${callbackDto.error}`)
+    }
+
+    // Exchange code for tokens
+    const tokenResponse = await this.exchangeCodeForTokens(callbackDto.code)
+
+    // Fetch user profile
+    const spotifyUser = await this.fetchSpotifyUserProfile(tokenResponse.access_token)
+
+    // Check if user already exists
+    let user = await this.usersService.findByMusicId(spotifyUser.id)
+
+    if (user) {
+      // Update existing user's tokens
+      user = await this.usersService.update(user.id, {
+        accessToken: this.cryptoService.encrypt(tokenResponse.access_token),
+        refreshToken: this.cryptoService.encrypt(tokenResponse.refresh_token),
+        displayName: spotifyUser.display_name || user.displayName,
+        email: spotifyUser.email || user.email,
+      })
+    } else {
+      // Create new user
+      user = await this.usersService.create({
+        email: spotifyUser.email,
+        displayName: spotifyUser.display_name || `Spotify User ${spotifyUser.id}`,
+        musicProvider: MusicProvider.SPOTIFY,
+        musicId: spotifyUser.id,
+        accessToken: this.cryptoService.encrypt(tokenResponse.access_token),
+        refreshToken: this.cryptoService.encrypt(tokenResponse.refresh_token),
+      })
+    }
+
+    // Generate JWT tokens for our app
+    const jwtTokens = await this.authService.generateTokens(user)
+
+    return {
+      user: user.toPublic(),
+      tokens: jwtTokens,
+    }
+  }
+
+  /**
+   * Refresh Spotify access token
+   */
+  async refreshSpotifyToken(userId: string): Promise<string> {
+    const user = await this.usersService.findOne(userId)
+
+    if (user.musicProvider !== MusicProvider.SPOTIFY) {
+      throw new BadRequestException("User is not a Spotify user")
+    }
+
+    const decryptedRefreshToken = this.cryptoService.decrypt(user.refreshToken)
+
+    const params = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: decryptedRefreshToken,
+    })
+
+    const authHeader = Buffer.from(`${this.spotifyClientId}:${this.spotifyClientSecret}`).toString("base64")
+
+    try {
+      const response = await fetch(this.spotifyTokenUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Authorization: `Basic ${authHeader}`,
+        },
+        body: params.toString(),
+      })
+
+      if (!response.ok) {
+        const error = await response.text()
+        throw new Error(`Spotify token refresh failed: ${error}`)
+      }
+
+      const tokenResponse: SpotifyTokenResponse = await response.json()
+
+      // Update user's access token (and refresh token if provided)
+      await this.usersService.update(userId, {
+        accessToken: this.cryptoService.encrypt(tokenResponse.access_token),
+        ...(tokenResponse.refresh_token && {
+          refreshToken: this.cryptoService.encrypt(tokenResponse.refresh_token),
+        }),
+      })
+
+      return tokenResponse.access_token
+    } catch (error) {
+      throw new InternalServerErrorException(`Failed to refresh Spotify token: ${error.message}`)
+    }
+  }
+
+  /**
+   * Get decrypted Spotify access token for a user
+   */
+  async getDecryptedAccessToken(userId: string): Promise<string> {
+    const user = await this.usersService.findOne(userId)
+
+    if (user.musicProvider !== MusicProvider.SPOTIFY) {
+      throw new BadRequestException("User is not a Spotify user")
+    }
+
+    return this.cryptoService.decrypt(user.accessToken)
+  }
+}


### PR DESCRIPTION
closes #112

## Enable Spotify Login Integration

This PR adds support for user authentication via Spotify. Key functionality includes:

- Redirecting users to Spotify's OAuth authorization URL
- Handling callback at `/auth/spotify/callback` with the authorization code
- Exchanging the code for access and refresh tokens
- Calling Spotify's `/me` endpoint to retrieve user profile data
- Persisting user information and tokens in the database
- Securely hashing tokens before storage for added security
